### PR TITLE
Update clojure and tools.cli versions

### DIFF
--- a/resources/leiningen/new/cmd/project.clj
+++ b/resources/leiningen/new/cmd/project.clj
@@ -2,7 +2,7 @@
   :description "Command Line Tool {{name}}"
   :licence "FIX ME Licence"
   :url "http://www.example.com/FIXME"
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/tools.cli "0.4.2"]]
+  :dependencies [[org.clojure/clojure "1.12.0"]
+                 [org.clojure/tools.cli "1.1.230"]]
   :main {{name}}.core)
 


### PR DESCRIPTION
作成されるコマンドのproject.cljに記述される org.clojure/clojure と org.clojure/tools.cli のバージョンを2025/05/19現在の最新バージョンとした。